### PR TITLE
Rejuvenate log levels (C/1000)

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
@@ -408,26 +408,26 @@ public abstract class FindBugs {
 
         if (verbose || commandLine.setExitCode()) {
             LOG.log(FINE, "Warnings generated: {0}", bugCount);
-            LOG.log(FINE, "Missing classes: {0}", missingClassCount);
+            LOG.log(FINER, "Missing classes: {0}", missingClassCount);
             LOG.log(FINE, "Analysis errors: {0}", errorCount);
         }
 
         if (commandLine.setExitCode()) {
             int exitCode = 0;
-            LOG.info("Calculating exit code...");
+            LOG.finer("Calculating exit code...");
             if (errorCount > 0) {
                 exitCode |= ExitCodes.ERROR_FLAG;
                 LOG.log(FINE, "Setting 'errors encountered' flag ({0})", ExitCodes.ERROR_FLAG);
             }
             if (missingClassCount > 0) {
                 exitCode |= ExitCodes.MISSING_CLASS_FLAG;
-                LOG.log(FINE, "Setting 'missing class' flag ({0})", ExitCodes.MISSING_CLASS_FLAG);
+                LOG.log(FINER, "Setting 'missing class' flag ({0})", ExitCodes.MISSING_CLASS_FLAG);
             }
             if (bugCount > 0) {
                 exitCode |= ExitCodes.BUGS_FOUND_FLAG;
-                LOG.log(FINE, "Setting 'bugs found' flag ({0})", ExitCodes.BUGS_FOUND_FLAG);
+                LOG.log(FINER, "Setting 'bugs found' flag ({0})", ExitCodes.BUGS_FOUND_FLAG);
             }
-            LOG.log(FINE, "Exit code set to: {0}", exitCode);
+            LOG.log(FINER, "Exit code set to: {0}", exitCode);
 
             System.exit(exitCode);
         }
@@ -465,7 +465,7 @@ public abstract class FindBugs {
      * Show the overall FindBugs command synopsis.
      */
     public static void showSynopsis() {
-        LOG.warning("Usage: findbugs [general options] -textui [command line options...] [jar/zip/class files, directories...]");
+        LOG.finest("Usage: findbugs [general options] -textui [command line options...] [jar/zip/class files, directories...]");
     }
 
     /**

--- a/spotbugsTestCases/src/java/sfBugs/Bug3458246.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug3458246.java
@@ -23,7 +23,7 @@ public class Bug3458246 {
             processRequest(frontendRequest, messageEvent, "CHANNEL_IMAGES");
             break;
         default:
-            LOGGER.warning("Can't match " + frontEndUrl);
+            LOGGER.finest("Can't match " + frontEndUrl);
 
             return;
         }


### PR DESCRIPTION
We appreciate your previous feedback! Here's a reissue of https://github.com/spotbugs/spotbugs/pull/938 with a new version of our tool. The tool made fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: ecc79945da2161552925f77cfd9f36a0efc3085d

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
